### PR TITLE
fixes frequency ranges

### DIFF
--- a/synchrophasor/frame.py
+++ b/synchrophasor/frame.py
@@ -2069,7 +2069,7 @@ class DataFrame(CommonFrame):
             data_format = DataFrame._int2format(data_format)
 
         if data_format[3]:  # FREQ/DFREQ floating point
-            if not -32.767 <= freq <= 32.767:
+            if not 60. - 32.767 <= freq <= 60. + 32.767:
                 raise ValueError("FREQ must be in range -32.767 <= FREQ <= 32.767.")
 
             freq = unpack("!I", pack("!f", float(freq)))[0]


### PR DESCRIPTION
The PDC is returning the nominal value of the system frequency (i.e. ~60Hz) but the library is expecting the deviation from the nominal frequency and therefore is returning an error. This is also raised in one of the issues of the original repository. The Standard accepts both ways of sending the frequency but the library only supports the frequency deviations method.
The solution is basically to correct the frequency limits imposed by the library.